### PR TITLE
Azure media player timecode and html id fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,15 @@ This plugin adds small markers onto your timeline at the configured times.
 ## Getting Started
 Include the plugin CSS/javascript*after* the AMP script in the `<head>` of your html page:
 
-```<link href="timelineMarkers.css" rel="stylesheet">```<br />
+```<link href="timelineMarkers.css" rel="stylesheet">```
+
 ```<script src="timelineMarkers.js"></script>```
 
-<b>important: this sample plugin's video id is azuremediaplayer and is hardcoded in the timelinemarkers.js in the following line: ```var elements = document.getElementById("azuremediaplayer").getElementsByClassName(className);````<br/>
-if you change the video id in your own code, be sure you update it in the javascript file as well (this will be fixed soon) </b>
+**important: this sample plugin's video id is azuremediaplayer and is hardcoded in the timelinemarkers.js in the following line:**
+
+```var elements = document.getElementById("azuremediaplayer").getElementsByClassName(className);```
+
+**if you change the video id in your own code, be sure you update it in the javascript file as well (this will be fixed soon)**
 
 See example.html for how to enable the plugin 
 ## Options

--- a/README.md
+++ b/README.md
@@ -19,15 +19,10 @@ Include the plugin CSS/javascript*after* the AMP script in the `<head>` of your 
 
 ```<script src="timelineMarkers.js"></script>```
 
-**important: this sample plugin's video id is azuremediaplayer and is hardcoded in the timelinemarkers.js in the following line:**
+See example.html for how to enable the plugin
 
-```var elements = document.getElementById("azuremediaplayer").getElementsByClassName(className);```
-
-**if you change the video id in your own code, be sure you update it in the javascript file as well (this will be fixed soon)**
-
-See example.html for how to enable the plugin 
 ## Options
-Plugin currently receives input in the form of an array of times see below: 
+Plugin currently receives input in the form of an array of times see below:
 
     plugins: {
     

--- a/timelineMarkers.js
+++ b/timelineMarkers.js
@@ -15,7 +15,14 @@ var clear = document.getElementsByClassName('amp-timeline-marker');
 
         amp.plugin('timelineMarker', function (options) {
             var player = this;
-			
+
+            // integration with frameRateTimecodeCalculator plugin
+            // src: https://github.com/mconverti/media-services-javascript-azure-media-player-framerate-timecode-calculator-plugin
+            var frameRate = 100;
+            if (player && player.options_ && player.options_.plugins && player.options_.plugins.hasOwnProperty('frameRateTimecodeCalculator')) {
+              frameRate = player.frameRate();
+            }
+
             player.addEventListener(amp.eventName.durationchange, function () {
             duration  = player.duration();
             var playerId = player.id() || "azuremediaplayer";
@@ -74,7 +81,7 @@ var clear = document.getElementsByClassName('amp-timeline-marker');
                     var timeFragments = timeFormat.split(":");
                     if (timeFragments.length > 0) {
                         switch (timeFragments.length) {
-                            case 4: return (parseInt(timeFragments[0], 10) * 60 * 60) + (parseInt(timeFragments[1], 10) * 60) + parseInt(timeFragments[2], 10) + (timeFragments[3] / 100);
+                            case 4: return (parseInt(timeFragments[0], 10) * 60 * 60) + (parseInt(timeFragments[1], 10) * 60) + parseInt(timeFragments[2], 10) + (timeFragments[3] / frameRate);
                             case 3: return (parseInt(timeFragments[0], 10) * 60 * 60) + (parseInt(timeFragments[1], 10) * 60) + parseInt(timeFragments[2], 10);
                             case 2: return parseInt(timeFragments[0], 10) * 60 + parseInt(timeFragments[1], 10);
                             case 1: return parseInt(timeFragments[0], 10);

--- a/timelineMarkers.js
+++ b/timelineMarkers.js
@@ -19,14 +19,16 @@ var clear = document.getElementsByClassName('amp-timeline-marker');
             // integration with frameRateTimecodeCalculator plugin
             // src: https://github.com/mconverti/media-services-javascript-azure-media-player-framerate-timecode-calculator-plugin
             var frameRate = 100;
-            if (player && player.options_ && player.options_.plugins && player.options_.plugins.hasOwnProperty('frameRateTimecodeCalculator')) {
-              frameRate = player.frameRate();
-            }
 
             player.addEventListener(amp.eventName.durationchange, function () {
             duration  = player.duration();
             var playerId = player.id() || "azuremediaplayer";
             var progressControlSlider = getElementsByClassName("vjs-progress-control", "vjs-slider");
+
+            if (player && player.options_ && player.options_.plugins && player.options_.plugins.hasOwnProperty('frameRateTimecodeCalculator')) {
+                frameRate = player.frameRate();
+            }
+
             function getElementsByClassName(className, childClass) {
                 var elements = document.getElementById(playerId).getElementsByClassName(className);
                 var matches = [];

--- a/timelineMarkers.js
+++ b/timelineMarkers.js
@@ -18,9 +18,10 @@ var clear = document.getElementsByClassName('amp-timeline-marker');
 			
             player.addEventListener(amp.eventName.durationchange, function () {
             duration  = player.duration();
+            var playerId = player.id() || "azuremediaplayer";
             var progressControlSlider = getElementsByClassName("vjs-progress-control", "vjs-slider");
             function getElementsByClassName(className, childClass) {
-                var elements = document.getElementById("azuremediaplayer").getElementsByClassName(className);
+                var elements = document.getElementById(playerId).getElementsByClassName(className);
                 var matches = [];
 
                 function traverse(node) {


### PR DESCRIPTION
What's updated:
- handling custom `id` of Azure Media Player container
- integration with `media-services-javascript-azure-media-player-framerate-timecode-calculator-plugin  - real framerate is provided to timeline  https://github.com/mconverti/media-services-javascript-azure-media-player-framerate-timecode-calculator-plugin 